### PR TITLE
Revert "Update from twostraws/Ignite@dc47b87 to twostraws/Ignite@557cc7b"

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2402c0efdcb1acb84a981833b3c89d004fd43662d559e43ba1e4000117df1ecd",
+  "originHash" : "fbeb3db426003beb3aca23d17830c78116e218ec7af107ee763efffde3a28cfe",
   "pins" : [
     {
       "identity" : "ignite",
@@ -7,7 +7,7 @@
       "location" : "https://github.com/twostraws/Ignite",
       "state" : {
         "branch" : "main",
-        "revision" : "557cc7bb7ed5c983e4f64d59f34ee64163b894d3"
+        "revision" : "dc47b87dda90a81948652d8adcf1242eaa8ef307"
       }
     },
     {


### PR DESCRIPTION
Reverts japan-region-swift/Japan-region-swift#17

twostraws/Ignite@dc47b87dda90a81948652d8adcf1242eaa8ef307 から twostraws/Ignite@557cc7bb7ed5c983e4f64d59f34ee64163b894d3 の間に含まれていた twostraws/Ignite#816 を中心とする破壊的変更により、マイグレーションの必要が生じ、またマイグレーションを行なっても意図しないレイアウト崩れや実行時間（`swift run`）の大幅な所要時間増加が見られたため、再度 twostraws/Ignite@dc47b87dda90a81948652d8adcf1242eaa8ef307 を採用する。